### PR TITLE
Traffic Light Detection Node Publish to '/traffic_waypoint'

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -80,6 +80,7 @@ class TLDetector(object):
         self.has_image = True
         self.camera_image = msg
         light_wp, state = self.process_traffic_lights()
+        rospy.logwarn("Closest light waypoint= {0}, light state= {1}".format(light_wp, state))
 
         '''
         Publish upcoming red lights at camera frequency.
@@ -123,14 +124,16 @@ class TLDetector(object):
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
-        if(not self.has_image):
-            self.prev_light_loc = None
-            return False
+        # if(not self.has_image):
+        #     self.prev_light_loc = None
+        #     return False
 
-        cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
+        # cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
 
-        #Get classification
-        return self.light_classifier.get_classification(cv_image)
+        # #Get classification
+        # return self.light_classifier.get_classification(cv_image)
+
+        return light.state  # TODO implement real classification, this are true values just for testing
 
     def process_traffic_lights(self):
         """Finds closest visible traffic light, if one exists, and determines its

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -60,7 +60,7 @@ class TLDetector(object):
     def waypoints_cb(self, waypoints):
         self.waypoints = waypoints
 
-        # setup k-d tree in order to find the closest path waypoint to the given position [get_closest_waypoint(pose)]
+        # setup k-d tree in order to find the closest path waypoint to the given position [get_closest_waypoint(position)]
         # the code is copied from waypoints_cb(pose) in ros/src/waypoint_updater/waypoint_updater.py written by https://github.com/ysonggit
         if not self.waypoints_2d:
             self.waypoints_2d = [[waypoint.pose.pose.position.x, waypoint.pose.pose.position.y] for waypoint in waypoints.waypoints]
@@ -100,17 +100,16 @@ class TLDetector(object):
             self.upcoming_red_light_pub.publish(Int32(self.last_wp))
         self.state_count += 1
 
-    def get_closest_waypoint(self, pose):
+    def get_closest_waypoint(self, position):
         """Identifies the closest path waypoint to the given position
             https://en.wikipedia.org/wiki/Closest_pair_of_points_problem
         Args:
-            pose (Pose): position to match a waypoint to
+            position [x, y]: position to match a waypoint to
 
         Returns:
             int: index of the closest waypoint in self.waypoints
 
         """
-        position = [pose.position.x, pose.position.y]
         # cKDTree.query() returns (distance, index), but only index is needed
         return self.waypoint_tree.query(position)[1]
 
@@ -150,7 +149,7 @@ class TLDetector(object):
         # List of positions that correspond to the line to stop in front of for a given intersection
         stop_line_positions = self.config['stop_line_positions']
         if self.pose:
-            car_waypoint_idx = self.get_closest_waypoint(self.pose.pose)
+            car_waypoint_idx = self.get_closest_waypoint([self.pose.pose.position.x, self.pose.pose.position.y])
 
             # find the closest visible traffic light (if one exists)
             min_stop_line_dist = len(self.waypoints.waypoints)

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -132,6 +132,7 @@ class TLDetector(object):
 
         """
         light = None
+        light_wp = None
 
         # List of positions that correspond to the line to stop in front of for a given intersection
         stop_line_positions = self.config['stop_line_positions']
@@ -140,7 +141,7 @@ class TLDetector(object):
 
         #TODO find the closest visible traffic light (if one exists)
 
-        if light:
+        if light and light_wp:
             state = self.get_light_state(light)
             return light_wp, state
         self.waypoints = None


### PR DESCRIPTION
This is the first part of the Traffic Light Detection Node.
The closest `stop_line_waypoint_idx` and the state of the traffic light are published to `/traffic_waypoint`.

`get_light_state(light)` returns true data provided for testing.

---
Problems:
 - when enabling camera the fps in the emulator drop to 0-1 (maybe this is my pc => I just tested it with a different PC and it works with ~45FPS, see screenshot).
    - ~~Maybe we can only work with every third or fourth image.~~ 😞 Did not help me...

Missing:
 - the real classification of traffic light state

![image](https://user-images.githubusercontent.com/17356275/51898309-eeda2200-23b0-11e9-9567-d9c7a0eaa4b4.png)

