### PR TITLE
FIX: smaller displacement and relative angle thresholds in waypoint follower

### DIFF
--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -18,7 +18,7 @@ class TwistController(object):
             max_steer_angle=cp.max_steer_angle)
 
         self.cp = cp
-        self.pid = PID(kp=5, ki=0.5, kd=0.5, mn=cp.decel_limit, mx=cp.accel_limit)
+        self.pid = PID(kp=0.3, ki=0.1, kd=0.0, mn=cp.decel_limit, mx=cp.accel_limit)
         self.s_lpf = LowPassFilter(tau = 3, ts = 1)
         self.t_lpf = LowPassFilter(tau = 3, ts = 1)
 

--- a/ros/src/waypoint_follower/include/pure_pursuit_core.h
+++ b/ros/src/waypoint_follower/include/pure_pursuit_core.h
@@ -98,8 +98,8 @@ public:
     , initial_velocity_(5.0)
     , lookahead_distance_calc_ratio_(2.0)
     , minimum_lookahead_distance_(6.0)
-    , displacement_threshold_(0.2)
-    , relative_angle_threshold_(5.)
+    , displacement_threshold_(0.02)//0.2
+    , relative_angle_threshold_(0.5)//5.0
     , waypoint_set_(false)
     , pose_set_(false)
     , velocity_set_(false)


### PR DESCRIPTION
Hi,
I changed the displacement and relative angle thresholds in waypoint_follower node, so that it generates a new trajectory more often, when it deviates from the waypoints generated by the updater.
I tested in my VM and the car appears to follow closer the waypoints.

Additionally, I used the previous values ​​for the PID controller, because the new ones decelerated the car very quickly and drives it erratically.

Please, test it.


![screenshot from 2019-01-31 19-25-42](https://user-images.githubusercontent.com/1189145/52077096-6ca85400-2590-11e9-8fab-eab52fbcbe98.png)