### PR TITLE
FIX: printing detector logs from callback function intervenes the car's PID response

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -80,7 +80,7 @@ class TLDetector(object):
         self.has_image = True
         self.camera_image = msg
         light_wp, state = self.process_traffic_lights()
-        rospy.logwarn("Closest light waypoint= {0}, light state= {1}".format(light_wp, state))
+        #rospy.logwarn("Closest light waypoint= {0}, light state= {1}".format(light_wp, state))
 
         '''
         Publish upcoming red lights at camera frequency.


### PR DESCRIPTION
The latest merge breaks the car's lane following behavior because of the too frequent logging messages in the `image_cb()` function. 

@pperle if you test the current master branch with the autonomous mode, you will see the car cannot follow the lane.