### PR TITLE
FIX: now the car stops before the line when a red light is detected

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -13,7 +13,6 @@ import cv2
 import yaml
 
 STATE_COUNT_THRESHOLD = 3
-IMAGE_CB_THRESHOLD = 5
 
 class TLDetector(object):
     def __init__(self):
@@ -52,7 +51,6 @@ class TLDetector(object):
         self.last_state = TrafficLight.UNKNOWN
         self.last_wp = -1
         self.state_count = 0
-        self.image_counter = 0
 
         rospy.spin()
 
@@ -79,11 +77,6 @@ class TLDetector(object):
             msg (Image): image from car-mounted camera
 
         """
-        if self.image_counter < IMAGE_CB_THRESHOLD:
-            self.image_counter += 1
-            return
-        else:
-            self.image_counter = 0
 
         self.has_image = True
         self.camera_image = msg

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -16,7 +16,7 @@ class Controller(object):
         self.yaw_controller = YawController(wheel_base, steer_ratio, 0.1, max_lat_accel, max_steer_angle)
 
         kp = 0.3
-        ki = 0.1
+        ki = 0
         kd = 1
         mn = 0.0  # Minimum throttle value
         mx = 0.2  # Maximum throttle value

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -23,7 +23,7 @@ as well as to verify your TL classifier.
 TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 '''
 
-LOOKAHEAD_WPS = 50 # Number of waypoints we will publish. 200 are too many, car lost itself in the middle...
+LOOKAHEAD_WPS = 150 # Number of waypoints we will publish. 200 are too many, car lost itself in the middle...
 MAX_DECEL = 10
 
 class WaypointUpdater(object):
@@ -37,7 +37,7 @@ class WaypointUpdater(object):
         # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
 
 
-        self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
+        self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=5)
 
         # TODO: Add other member variables you need below
         self.pose = None
@@ -49,7 +49,7 @@ class WaypointUpdater(object):
         self.loop()
 
     def loop(self):
-        rate = rospy.Rate(25)
+        rate = rospy.Rate(5)
         while not rospy.is_shutdown():
             if self.pose and self.base_waypoints:
                 # get closest waypoint
@@ -103,10 +103,9 @@ class WaypointUpdater(object):
             stop_idx = max(self.stopline_wp_idx - closest_idx - 2, 0) # Two waypoints back from so front of car stops at line
             dist = self.distance(waypoints, i, stop_idx)
             vel = math.sqrt(2 * MAX_DECEL * dist)
-
+            vel = 0.02 * MAX_DECEL * dist
             if vel < 1:
                 vel = 0.
-
             p.twist.twist.linear.x = min(vel, wp.twist.twist.linear.x)
             temp.append(p)
         return temp


### PR DESCRIPTION
Hi,

I noted the following while testing:

* It is necessary to generate more than 50 waypoints to properly brake with enough time.
* The Ki coefficient should be zero or close to zero in order to decrease the throttle when is required.
* Increasing the queue size in the publisher of the full_waypoint topic, from 1 to 5, reduces the car deviation.
* In the line 106 of waypoint_updater.py, I changed the square root by multiplication by a constant. I think this constant should be proportional to the current speed. 0.02 works for all the cases I tested.